### PR TITLE
Fixes to keyboard code, making PC-compatible initialization working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ESP32 PS/2 mouse/keyboard emulation library
 This library allows ESP32 to emulate ps2 keyboard and/or mouse.
+PC fixes have been added from previous forkes to make it more reliable during post.
 
 # Electrical connections
 

--- a/src/esp32-ps2dev.cpp
+++ b/src/esp32-ps2dev.cpp
@@ -646,9 +646,9 @@ int PS2Keyboard::reply_to_host(uint8_t host_cmd) {
 #if defined(_ESP32_PS2DEV_DEBUG_)
       _ESP32_PS2DEV_DEBUG_.println("PS2Keyboard::reply_to_host: Set/reset LEDs command received");
 #endif  // _ESP32_PS2DEV_DEBUG_
-      ack();
+      while (write(0xAF) != 0) delay(1);
       if (!read(&val)) {
-        ack();
+         while (write(0xAF) != 0) delay(1);
         _led_scroll_lock = ((val & 1) != 0);
         _led_num_lock = ((val & 2) != 0);
         _led_caps_lock = ((val & 4) != 0);

--- a/src/esp32-ps2dev.cpp
+++ b/src/esp32-ps2dev.cpp
@@ -565,7 +565,8 @@ void PS2Keyboard::begin() {
 
   xSemaphoreTake(_mutex_bus, portMAX_DELAY);
   delayMicroseconds(BYTE_INTERVAL_MICROS);
-  while (write(0xAA) != 0) delay(200);
+  delay(200);
+  write(0xAA);
   xSemaphoreGive(_mutex_bus);
 }
 bool PS2Keyboard::data_reporting_enabled() { return _data_reporting_enabled; }

--- a/src/esp32-ps2dev.cpp
+++ b/src/esp32-ps2dev.cpp
@@ -624,10 +624,8 @@ int PS2Keyboard::reply_to_host(uint8_t host_cmd) {
       _ESP32_PS2DEV_DEBUG_.println("PS2Keyboard::reply_to_host: Get device id command received");
 #endif  // _ESP32_PS2DEV_DEBUG_
       ack();
-      write(0xAB);
-      delayMicroseconds(BYTE_INTERVAL_MICROS);
-      write(0x83);
-      delayMicroseconds(BYTE_INTERVAL_MICROS);
+      while (write(0xAB) != 0) delay(1); // ensure ID gets writed, some hosts may be sensitive
+      while (write(0x83) != 0) delay(1); // this is critical for combined ports (they decide mouse/kb on this)
       break;
     case Command::SET_SCAN_CODE_SET:  // set scan code set
 #if defined(_ESP32_PS2DEV_DEBUG_)

--- a/src/esp32-ps2dev.cpp
+++ b/src/esp32-ps2dev.cpp
@@ -581,7 +581,7 @@ int PS2Keyboard::reply_to_host(uint8_t host_cmd) {
       _ESP32_PS2DEV_DEBUG_.println("PS2Keyboard::reply_to_host: Reset command received");
 #endif  // _ESP32_PS2DEV_DEBUG_
       // the while loop lets us wait for the host to be ready
-      while (write((uint8_t)Command::ACK) != 0) delay(1);
+      ack(); // ack() provides delay, some systems need it
       while (write((uint8_t)Command::BAT_SUCCESS) != 0) delay(1);
       _data_reporting_enabled = false;
       break;


### PR DESCRIPTION
Hello! First of all, very nice approach using multi-threading. 

In my testing I discovered three different issues  that preventing the code from working in many PC-compatible systems and making it through the post succesfully. I made only changes related to keyboard part of the code (no mouse fixes yet).

All issues where tested using DEBUG ifdef's and strategically set serial console prints, ommited in these commits.

**ISSUE 1**
-Testing on: Toshiba Satellite 205CDS, combined keyboard-mouse PS/2 port, mini-DIN connector.
-Problem: This laptop uses the GET DEVICE ID COMMAND to decide if the divice connected is a Keyboard or a Mouse. For some reason the two byte writes for the ID were failing, and because of that the laptop defaulted the device to be a Mouse (and of course that won't work).
-SOLUTION: Adding two While loops to retry the writes as many times as needed solved the problem.

**ISSUE 2**
-Testing on: Toshiba Satellite 205CDS, combined keyboard-mouse PS/2 port, mini-DIN connector. Possibly affecting more systems.
-Problem: At first power-on the interface was waiting to send 0xAA command in a loop of Write-tries, during PS2Keyboard::begin(). This for some reason caused the interface to miss critical first-hand commands from the laptop, like the GET DEVICE ID discussed above. As a result the laptop was also defaulting the keyboard as a mouse.
-Solution: BAT SUCCESS code (0xAA) should ALWAYS be sent a coulple of houndred of milliseconds after first power up, regardless of bus state. Added a 200ms delay and a ensured write() solved the problem.

**ISSUE 3**
-Testing on: Intel 486 PC-Compatible desktop system, 5 pin full size DIN connector.
-Problem: For some reason the host wasn't getting the ACKs correctly during the SET/RESET LEDS command. This caused the host to abort initialization and ignore the keyboard from that function in advance.
-Solution: Changed the ACKs to While-Write loops solved the problem. Need testing in more implementations that use LED info, to ensure it's working OK.

Hope this helps. I'm new to GitHub, I'm king of a noob on repositories, so tell me if I'm doing something wrong.

Cheers!